### PR TITLE
Added fontawesome css to display menu icons on circular-menu

### DIFF
--- a/projects/circular-menu/index.html
+++ b/projects/circular-menu/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Circular Menu</title>
     <link rel="stylesheet" href="style.css" />
-    k
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   </head>
 
   <body>


### PR DESCRIPTION

**Proposed changes:**
Added fontawesome css to display menu icons on circular-menu

**Type of change:**

- [x] Bug fix (non-breaking change which fixes an issue)


**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

**Additional info (if any):**
<img width="552" alt="Screenshot 2022-10-16 at 3 56 51 PM" src="https://user-images.githubusercontent.com/96119541/196029741-d8c646f3-c2b4-47aa-9168-5ea1b183297a.png">
<img width="633" alt="Screenshot 2022-10-16 at 3 56 11 PM" src="https://user-images.githubusercontent.com/96119541/196029745-d63c965e-6340-40c1-88e3-0353d519a775.png">

