### PR TITLE
New feature : Hacktoberfest 2022 stats counter for this repo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Raj V.
 <a href="https://www.linkedin.com/in/varsani-raj/">LinkedIn</a>
 <a href="https://github.com/RajVarsani">Github</a>
 
+## 🎃 Hacktoberfest 2022 Stats
+
+Checkout Hacktoberfest 2022 stats for this repository :
+
+[![Hacktoberfest 2022 stats](https://img.shields.io/github/hacktoberfest/2022/RajVarsani/html-archives?label=HACKTOBERFEST%20-%20HTML%20ARCHIVES&style=for-the-badge)](https://github.com/RajVarsani/html-archives/pulls?q=is%3Apr+is%3Amerged+created%3A2022-10-01..2022-10-31+)
+
 ## 📄 License
 
 [MIT](./LICENSE.md)


### PR DESCRIPTION
**Issue reference:**
#228 : Feature Request: A cool counter in the README that shows the number of PRs during Hacktoberfest

**Proposed changes:**
New Feature :Add the Hacktoberfest 2022 stat counter to the README.MD

**Type of change:**
Added the Hacktoberfest 2022 stat counter to the README.MD

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

Preview :

![image](https://user-images.githubusercontent.com/40513836/197005175-58a840d1-0939-4e4c-ab51-b4eea32b1c4b.png)

